### PR TITLE
Add the auc function

### DIFF
--- a/src/utils.R
+++ b/src/utils.R
@@ -4,6 +4,7 @@ library(plyr)
 library(tidyverse)
 library(doMC)
 library(optparse)
+library(ROCR)
 
 OPT_LIST <- list(
   make_option(c("-v", "--version"), default = "v3",

--- a/src/utils.R
+++ b/src/utils.R
@@ -275,3 +275,10 @@ normal_prob_area_plot <- function(
    + geom_ribbon(data = area, mapping = aes(x = x, ymin = ymin, ymax = ymax))
    + scale_x_continuous(limits = limits))
 }
+
+auc <- function(labels, pred) {
+  pred.df <- prediction(pred, labels)
+  res <- performance(pred.df, "auc")
+  res <- unlist(slot(res, "y.values"))
+  return(res)
+}


### PR DESCRIPTION
The case study fails with the error:
```
✖ could not find function "auc"
```
The error comes from [this line](https://github.com/stanford-policylab/simple-rules/blob/ac1efdb3cc22258000662af9076f0a34a1ff679e/src/case_study.R#L167):
```
summarize(auc = auc(labels, pred))
```
I was not able to find an `auc` function in any of the used libraries, or other R libraries that is compatible with this code, so I added one in the utils file. It makes case study run without errors.